### PR TITLE
Command `\makeproof` will fail for appendix mode if `hyperref` is loaded

### DIFF
--- a/moveproofs.sty
+++ b/moveproofs.sty
@@ -111,7 +111,11 @@
 % Example usage: \appendixproof{theorem_one}
 \DeclareDocumentCommand{\appendixproof}{s m}{
 \ifmoveproofstoappendix
-    \subsection{\protect\MPGetTitle{#2}}\label{#2_proof}
+    \IfPackageLoadedTF{hyperref}{
+        \subsection{\texorpdfstring{\protect\MPGetTitle{#2}}{\autoref{#2}}}
+    }{
+        \subsection{\protect\MPGetTitle{#2}}
+    }\label{#2_proof}
     \IfBooleanTF{#1}{
         \MPGetProof{#2}%
     }{

--- a/moveproofs.sty
+++ b/moveproofs.sty
@@ -111,6 +111,9 @@
 % Example usage: \appendixproof{theorem_one}
 \DeclareDocumentCommand{\appendixproof}{s m}{
 \ifmoveproofstoappendix
+    % If MP title contains hyperref link to reference that cannot be resolved at early runs
+    % of pdftex then pdftex will fail while compiling table of contents.
+    % Checked for Tex Live 2026.
     \IfPackageLoadedTF{hyperref}{
         \subsection{\texorpdfstring{\protect\MPGetTitle{#2}}{\autoref{#2}}}
     }{


### PR DESCRIPTION
If user uses both of `moveproofs` and `hyperref` packages together then pdflatex will fail to process TOC for appendix subsections containing proofs. Please, find the minimal non-working example named `mnwe.tex` below.
```latex
\documentclass{article}

\usepackage{lipsum}
\usepackage{amsthm}
\newtheorem{theorem}{Theorem}

\usepackage{hyperref}

\usepackage[location=appendix]{moveproofs}


\begin{document}
    \section{Theorems}
    \begin{theorem}\label{th:1}
        \lipsum[2-4]
    \end{theorem}
    \makeproof{th:1}{
        \lipsum[2-4]
    }{Proof of Theorem \ref{th:1}}
\end{document}
```
If user tries to render `mnwe.tex` to PDF then will get the error because TOC wants strings for subsection titles rather than TeX code.
```bash
> docker run --rm -v $(pwd):/work -w /work -it texlive/texlive:latest latexmk -pdf -pdflatex mnwe.tex

...
! Argument of \pgfkeys@@normal has an extra }.
...
```

This PR extends the `moveproof` package's command `\appendixproof` to handle this case.
This PR was tested with `TeX Live 2024` and `latexmk v4.85`.