### PR TITLE
Import moveproofs will crash if there is no \makeproof

### DIFF
--- a/moveproofs.sty
+++ b/moveproofs.sty
@@ -15,6 +15,10 @@
 
 % Namespace our key-value store.
 \pgfkeys{/moveproofs/.is family}
+% Initialize empty proof list so that documents with no proofs compile.
+\pgfkeys{moveproofs,
+  proofs/list/.initial={}
+}
 
 % Set up the 'location' option, which may be set to 'inline' (don't move proofs) or 'appendix' (move proofs to the appendix).
 \newif\ifmoveproofstoappendix
@@ -61,6 +65,10 @@
 \makeatother
 \provideenvironment{proof}{ \par\noindent{\bfseries\upshape Proof\ }}{\MPQED}
 
+% Indicates if there are any proofs.
+\newif\ifMPproofsdefined
+\MPproofsdefinedfalse
+
 % Low-level commands for manipulating the kv-store.
 \newcommand{\MPProofToStore}{}
 \DeclareDocumentCommand{\MPStoreProof}{s m +m m}{
@@ -70,6 +78,7 @@
     }{
         \renewcommand{\MPProofToStore}[1]{\appendixproof{##1}}
     }
+    \MPproofsdefinedtrue
     \pgfkeys{moveproofs, 
             proofs/#2/content/.code={#3},
             proofs/#2/title/.code={#4},
@@ -140,13 +149,16 @@
     \else
         \ifmanualappendix
         \else
-            \ifnoappendix
-                \oldappendix
+            \ifMPproofsdefined
+                \ifnoappendix
+                    \oldappendix
+                \fi
+                \appendixprelim
+                \appendixproofsection{\MPAppendixSectionName}
+                \pgfkeys{moveproofs, proofs/list}
+                \proofsinsertedtrue
+
             \fi
-            \appendixprelim
-            \appendixproofsection{\MPAppendixSectionName}
-            \pgfkeys{moveproofs, proofs/list}
-            \proofsinsertedtrue
         \fi
     \fi
 }


### PR DESCRIPTION
If user imports `moveproofs` package but has no `\makeproof` calls in his TeX then it crashes with the error like below:
```text
! Package pgfkeys Error: I do not know the key '/moveproofs/proofs/list' and I am going to ignore it. Perhaps you misspelled it.
```
Please, find the minimal non-working example named mnwe.tex below.
```tex
\documentclass{article}

\usepackage{lipsum}
\usepackage{amsthm}
\newtheorem{theorem}{Theorem}

\usepackage{hyperref}

\usepackage[location=appendix]{moveproofs}


\begin{document}
\end{document}
```

To check `mnwe.tex` you can use next bash:
```bash
docker run --rm -v $(pwd):/work -w /work -it texlive/texlive:latest latexmk -pdf -pdflatex mnwe.tex
```

This PR introduces the flag `\ifMPproofsdefined` to indicate if there is no proofs and initializes proof list as empty one.
This PR was tested with TeX Live 2026.